### PR TITLE
Bild von Luna Lovegood aus Wikipedia hinzugefügt

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,3 +17,5 @@ Many people in the Harry Potter series think she is a strange girl. This has led
 > things we lose have a way of coming back to us
 > in the end.
 > If not always in the ways we expect.
+
+<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Evanna_Lynch_acrylic_ink.jpg/800px-Evanna_Lynch_acrylic_ink.jpg"/>


### PR DESCRIPTION
Bild von Luna Lovegood mit Link aus Wikipedia folgendermaßen hinzugefügt: <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Evanna_Lynch_acrylic_ink.jpg/800px-Evanna_Lynch_acrylic_ink.jpg"/> . Fixes: #9 